### PR TITLE
Delete obsolete 'serve' shell script.

### DIFF
--- a/serve
+++ b/serve
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-trap 'kill 0' SIGINT SIGTERM EXIT
-
-(while true; do coffee -cw -o build/ coffee/; done) &
-
-python -m SimpleHTTPServer


### PR DESCRIPTION
This no longer even works due to recent re-org, and is not worth maintaining when we have Grunt.